### PR TITLE
Edit syntax error [poblic] in prository.cs

### DIFF
--- a/Uplift.DataAccess/Data/Repository/Repository.cs
+++ b/Uplift.DataAccess/Data/Repository/Repository.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Uplift.DataAccess.Data.Repository
 {
-    poblic class Repository<T> : 
+    public class Repository<T>
     {
     }
 }


### PR DESCRIPTION
I found a syntax error in Repository class. 

1. poblic  chane to public .

2. delete ( : )